### PR TITLE
add destroy method

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,9 @@ var assertive = new LiveRegion({
 ```js
 region.announce('Hello Fred', 5e3);
 ```
+
+### `LiveRegion#destroy`
+removes the live region DOM node inserted on initialization
+```js
+region.destroy();
+```

--- a/index.js
+++ b/index.js
@@ -65,6 +65,15 @@ LiveRegion.prototype.announce = function (msg, expire) {
 };
 
 /**
+ * destroy
+ * Removes the live region DOM node inserted on initialization
+ */
+
+LiveRegion.prototype.destroy = function () {
+  this.region.parentNode.removeChild(this.region)
+};
+
+/**
  * Expose LiveRegion
  */
 

--- a/test/index.js
+++ b/test/index.js
@@ -29,9 +29,9 @@ describe('LiveRegion', function () {
   });
 
   describe('destroy', function () {
-    it('should remove region node from the DOM', function (done) {
+    it('should remove region node from the DOM', function () {
       polite.destroy();
-      assert.isNull(polite.region.parentNode);
+      assert.false(document.contains(polite.region);
     });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -28,4 +28,10 @@ describe('LiveRegion', function () {
     });
   });
 
+  describe('destroy', function () {
+    it('should remove region node from the DOM', function (done) {
+      polite.destroy();
+      assert.isNull(polite.region.parentNode);
+    });
+  });
 });


### PR DESCRIPTION
Adds destroy method to allow cleanup after live region is no longer needed. Closes https://github.com/schne324/live-region/issues/1.